### PR TITLE
switch to tracker-sparql-3.0

### DIFF
--- a/src/gallery/tracker/qdocumentgallery_tracker.cpp
+++ b/src/gallery/tracker/qdocumentgallery_tracker.cpp
@@ -333,7 +333,7 @@ QDocumentGallery::QDocumentGallery(QObject *parent)
     qDBusRegisterMetaType<QVector<QGalleryTrackerGraphUpdate> >();
 
     g_type_init();
-    d->connection = tracker_sparql_connection_get(0, 0);
+    d->connection = tracker_sparql_connection_bus_new ("org.freedesktop.Tracker3.Miner.Files", NULL, NULL, NULL);
 }
 
 QDocumentGallery::~QDocumentGallery()

--- a/src/gallery/tracker/tracker.pri
+++ b/src/gallery/tracker/tracker.pri
@@ -3,7 +3,7 @@ INCLUDEPATH += $$PWD
 QT += dbus
 
 CONFIG += link_pkgconfig
-PKGCONFIG_PRIVATE += tracker-sparql-2.0
+PKGCONFIG_PRIVATE += tracker-sparql-3.0
 
 PRIVATE_HEADERS += \
         $$PWD/qgallerydbusinterface_p.h \

--- a/tests/auto/auto.pro
+++ b/tests/auto/auto.pro
@@ -16,7 +16,7 @@ SUBDIRS += \
 
 linux-*:qtHaveModule(dbus):contains(tracker_enabled, yes) {
     SUBDIRS += \
+            qgallerytrackerresultset_tracker \
             qgallerytrackerschema_tracker
-#        qgallerytrackerresultset_tracker \
 }
 

--- a/tests/auto/qgallerytrackerresultset_tracker/qgallerytrackerresultset_tracker.pro
+++ b/tests/auto/qgallerytrackerresultset_tracker/qgallerytrackerresultset_tracker.pro
@@ -1,6 +1,6 @@
 include(../auto.pri)
 
-QT += gallery-private
+QT += docgallery-private
 
 SOURCES += tst_qgallerytrackerresultset.cpp
 DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0

--- a/tests/auto/qgallerytrackerresultset_tracker/target_wrapper.sh
+++ b/tests/auto/qgallerytrackerresultset_tracker/target_wrapper.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+LD_LIBRARY_PATH=/usr/lib64${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+export LD_LIBRARY_PATH
+QT_PLUGIN_PATH=/usr/lib64/qt5/plugins${QT_PLUGIN_PATH:+:$QT_PLUGIN_PATH}
+export QT_PLUGIN_PATH
+exec "$@"

--- a/tests/auto/qgallerytrackerresultset_tracker/tst_qgallerytrackerresultset.cpp
+++ b/tests/auto/qgallerytrackerresultset_tracker/tst_qgallerytrackerresultset.cpp
@@ -51,6 +51,8 @@
 
 #include <QtTest/QtTest>
 
+QT_USE_DOCGALLERY_NAMESPACE
+
 Q_DECLARE_METATYPE(QVector<QStringList>)
 
 class QtTestQueryAdaptor;

--- a/tests/auto/qgallerytrackerschema_tracker/tst_qgallerytrackerschema.cpp
+++ b/tests/auto/qgallerytrackerschema_tracker/tst_qgallerytrackerschema.cpp
@@ -2234,7 +2234,7 @@ void tst_QGalleryTrackerSchema::queryResponseFilter_data()
         QGalleryFilter filter
                 = QDocumentGallery::lastModified > QDateTime(QDate(2008, 06, 01), QTime(12, 5, 8));
 
-        QTest::newRow("Image.lastModified > 2008-06-01T12:05:08")
+        QTest::newRow("Image.lastModified > 2008-06-01T12:05:08.000")
                 << "Image"
                 << QString()
                 << QGalleryQueryRequest::AllDescendants
@@ -2243,14 +2243,14 @@ void tst_QGalleryTrackerSchema::queryResponseFilter_data()
                     "WHERE {"
                         "?x a nmm:Photo . "
                         "?x tracker:available true "
-                        "FILTER((nfo:fileLastModified(?x)>'2008-06-01T12:05:08'))"
+                        "FILTER((nfo:fileLastModified(?x)>'2008-06-01T12:05:08.000'))"
                     "} "
                     "GROUP BY ?x";
     } {
         QGalleryFilter filter = !(
                 QDocumentGallery::lastModified > QDateTime(QDate(2008, 06, 01), QTime(12, 5, 8)));
 
-        QTest::newRow("!(Image.lastModified > 2008-06-01T12:05:08")
+        QTest::newRow("!(Image.lastModified > 2008-06-01T12:05:08.000")
                 << "Image"
                 << QString()
                 << QGalleryQueryRequest::AllDescendants
@@ -2259,7 +2259,7 @@ void tst_QGalleryTrackerSchema::queryResponseFilter_data()
                     "WHERE {"
                         "?x a nmm:Photo . "
                         "?x tracker:available true "
-                        "FILTER(!(nfo:fileLastModified(?x)>'2008-06-01T12:05:08'))"
+                        "FILTER(!(nfo:fileLastModified(?x)>'2008-06-01T12:05:08.000'))"
                     "} "
                     "GROUP BY ?x";
 


### PR DESCRIPTION
I am not sure how to validate if it works correctly. Something is probably still broken, because glacier-gallery doesn't show any files.

The tracker_sparql_connection_get should be replace by tracker_sparql_connection_bus_new according to migration guide
https://gnome.pages.gitlab.gnome.org/tracker/docs/api-preview/libtracker-sparql-3/ch28s11.html

The tracker must be newer than 3.1.1 (current most recent release). Following commit is required: https://gitlab.gnome.org/GNOME/tracker/-/commit/a11eb47ee19cc9849e790aa6331f242f9fa480a9